### PR TITLE
copr.py: fix rstrip not being invoked 

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -50,7 +50,7 @@ except ImportError:
             with open('/etc/os-release') as os_release_file:
                 os_release_data = {}
                 for line in os_release_file:
-                    os_release_key, os_release_value = line.rstrip.split('=')
+                    os_release_key, os_release_value = line.rstrip().split('=')
                     os_release_data[os_release_key] = os_release_value.strip('"')
                 return (os_release_data['NAME'], os_release_data['VERSION_ID'], None)
 


### PR DESCRIPTION
Previously it could throw if you weren't using supported Linux distribution:
```
AttributeError: 'builtin_function_or_method' object has no attribute 'split'
```
Encountered it running Fedora 33 with WSL 2. 